### PR TITLE
fix(build): use toLatin1 method instead of toAscii for QString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ hairless-midiserial
 Makefile
 *#
 *.autosave
+.qmake.stash

--- a/src/PortLatency_linux.cpp
+++ b/src/PortLatency_linux.cpp
@@ -43,7 +43,7 @@ bool PortLatency::swapAsync(bool setAsyncMode)
     if(!portName.startsWith("/dev/")) {
         portName.prepend("/dev/");
     }
-    int fd = open(portName.toAscii().data(), O_NONBLOCK);
+    int fd = open(portName.toLatin1().data(), O_NONBLOCK);
     if(fd <= 0) {
         emit errorMessage(QString("Failed to open serial port device %1 to lower latency").arg(portName));
         return false;


### PR DESCRIPTION
Hi there!

I've just ordered an Mega EverDrive Pro recently (not received yet) and am preparing my environment.
I can't build the project currently with QT5:

```
src/PortLatency_linux.cpp:46:28: error: 'class QString' has no member named 'toAscii'
```

Some info about `toAscii()` from QT4 documentation:

> If a codec has been set using QTextCodec::setCodecForCStrings(), it is
> used to convert Unicode to 8-bit char; otherwise this function does the
> same as toLatin1().

`toAscii` seems not to be in QT5 anymore.
Replacing it by `toLatin1()` helps, I don't know if it will break something else.

If you need a dockerfile to reproduce:
```
FROM debian:bullseye-slim

RUN set -x \
      && apt-get update \
      && apt-get install -y qt5-qmake make g++ pkg-config \
                            libasound2-dev \
                            qtbase5-dev-tools \
                            qtmultimedia5-dev \
                            libudev-dev

COPY . /app
WORKDIR /app

RUN set -x \
      && qmake \
      && make
```

I noticed a [PR upstream](https://github.com/projectgus/hairless-midiserial/pull/31/files) addressing the same issue and containing other fixes, but I'm not qualified enough to tell if it's relevant here or not.

Thanks!
